### PR TITLE
Some modifications to gcc_zilsd

### DIFF
--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -347,13 +347,14 @@ static const struct riscv_ext_version riscv_ext_version_table[] =
 
   {"zmmul", ISA_SPEC_CLASS_NONE, 1, 0},
 
-  {"zca",  ISA_SPEC_CLASS_NONE, 1, 0},
-  {"zcb",  ISA_SPEC_CLASS_NONE, 1, 0},
-  {"zce",  ISA_SPEC_CLASS_NONE, 1, 0},
-  {"zcf",  ISA_SPEC_CLASS_NONE, 1, 0},
-  {"zcd",  ISA_SPEC_CLASS_NONE, 1, 0},
-  {"zcmp", ISA_SPEC_CLASS_NONE, 1, 0},
-  {"zcmt", ISA_SPEC_CLASS_NONE, 1, 0},
+  {"zca",    ISA_SPEC_CLASS_NONE, 1, 0},
+  {"zcb",    ISA_SPEC_CLASS_NONE, 1, 0},
+  {"zce",    ISA_SPEC_CLASS_NONE, 1, 0},
+  {"zcf",    ISA_SPEC_CLASS_NONE, 1, 0},
+  {"zcd",    ISA_SPEC_CLASS_NONE, 1, 0},
+  {"zcmp",   ISA_SPEC_CLASS_NONE, 1, 0},
+  {"zcmt",   ISA_SPEC_CLASS_NONE, 1, 0},
+  {"zcmlsd", ISA_SPEC_CLASS_NONE, 1, 0},
 
   {"smaia",     ISA_SPEC_CLASS_NONE, 1, 0},
   {"smepmp",    ISA_SPEC_CLASS_NONE, 1, 0},
@@ -1726,6 +1727,7 @@ static const riscv_ext_flag_table_t riscv_ext_flag_table[] =
   {"zcd",     &gcc_options::x_riscv_zc_subext, MASK_ZCD},
   {"zcmp",    &gcc_options::x_riscv_zc_subext, MASK_ZCMP},
   {"zcmt",    &gcc_options::x_riscv_zc_subext, MASK_ZCMT},
+  {"zcmlsd",  &gcc_options::x_riscv_zc_subext, MASK_ZCMLSD},
 
   {"svinval", &gcc_options::x_riscv_sv_subext, MASK_SVINVAL},
   {"svnapot", &gcc_options::x_riscv_sv_subext, MASK_SVNAPOT},

--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -83,6 +83,10 @@ static const riscv_implied_info_t riscv_implied_info[] =
   {"zfinx", "zicsr"},
   {"zdinx", "zicsr"},
 
+  {"zclsd", "zilsd"},
+  {"zilsd", "zicsr"},
+  {"zclsd", "zicsr"},
+
   {"zk", "zkn"},
   {"zk", "zkr"},
   {"zk", "zkt"},
@@ -251,7 +255,7 @@ static const struct riscv_ext_version riscv_ext_version_table[] =
   {"zifencei", ISA_SPEC_CLASS_20190608, 2, 0},
 
   {"zicond", ISA_SPEC_CLASS_NONE, 1, 0},
-  {"zilsd",ISA_SPEC_CLASS_NONE, 2, 2},
+  {"zilsd",ISA_SPEC_CLASS_NONE, 1, 0},
 
   {"za64rs",  ISA_SPEC_CLASS_NONE, 1, 0},
   {"za128rs", ISA_SPEC_CLASS_NONE, 1, 0},
@@ -354,7 +358,7 @@ static const struct riscv_ext_version riscv_ext_version_table[] =
   {"zcd",    ISA_SPEC_CLASS_NONE, 1, 0},
   {"zcmp",   ISA_SPEC_CLASS_NONE, 1, 0},
   {"zcmt",   ISA_SPEC_CLASS_NONE, 1, 0},
-  {"zcmlsd", ISA_SPEC_CLASS_NONE, 1, 0},
+  {"zclsd",  ISA_SPEC_CLASS_NONE, 1, 0},
 
   {"smaia",     ISA_SPEC_CLASS_NONE, 1, 0},
   {"smepmp",    ISA_SPEC_CLASS_NONE, 1, 0},
@@ -1330,6 +1334,13 @@ riscv_subset_list::check_conflict_ext ()
 	      "%<-march=%s%>: z*inx conflicts with floating-point "
 	      "extensions",
 	      m_arch);
+  if (lookup ("zilsd") && m_xlen == 64)
+    error_at (m_loc, "%<-march=%s%>: zilsd extension supports in rv32 only",
+	      m_arch);
+
+  if (lookup ("zclsd") && m_xlen == 64)
+    error_at (m_loc, "%<-march=%s%>: zclsd extension supports in rv32 only",
+	      m_arch);
 
   /* 'H' hypervisor extension requires base ISA with 32 registers.  */
   if (lookup ("e") && lookup ("h"))
@@ -1727,7 +1738,7 @@ static const riscv_ext_flag_table_t riscv_ext_flag_table[] =
   {"zcd",     &gcc_options::x_riscv_zc_subext, MASK_ZCD},
   {"zcmp",    &gcc_options::x_riscv_zc_subext, MASK_ZCMP},
   {"zcmt",    &gcc_options::x_riscv_zc_subext, MASK_ZCMT},
-  {"zcmlsd",  &gcc_options::x_riscv_zc_subext, MASK_ZCMLSD},
+  {"zclsd",   &gcc_options::x_riscv_zc_subext, MASK_ZCLSD},
 
   {"svinval", &gcc_options::x_riscv_sv_subext, MASK_SVINVAL},
   {"svnapot", &gcc_options::x_riscv_sv_subext, MASK_SVNAPOT},

--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -251,6 +251,7 @@ static const struct riscv_ext_version riscv_ext_version_table[] =
   {"zifencei", ISA_SPEC_CLASS_20190608, 2, 0},
 
   {"zicond", ISA_SPEC_CLASS_NONE, 1, 0},
+  {"zilsd",ISA_SPEC_CLASS_NONE, 2, 2},
 
   {"za64rs",  ISA_SPEC_CLASS_NONE, 1, 0},
   {"za128rs", ISA_SPEC_CLASS_NONE, 1, 0},
@@ -1615,6 +1616,7 @@ static const riscv_ext_flag_table_t riscv_ext_flag_table[] =
   {"zicsr",    &gcc_options::x_riscv_zi_subext, MASK_ZICSR},
   {"zifencei", &gcc_options::x_riscv_zi_subext, MASK_ZIFENCEI},
   {"zicond",   &gcc_options::x_riscv_zi_subext, MASK_ZICOND},
+  {"zilsd", &gcc_options::x_riscv_zi_subext, MASK_ZILSD},
 
   {"za64rs", &gcc_options::x_riscv_za_subext, MASK_ZA64RS},
   {"za128rs", &gcc_options::x_riscv_za_subext, MASK_ZA128RS},

--- a/gcc/config/riscv/riscv-protos.h
+++ b/gcc/config/riscv/riscv-protos.h
@@ -154,6 +154,10 @@ extern bool riscv_epilogue_uses (unsigned int);
 extern bool riscv_can_use_return_insn (void);
 extern rtx riscv_function_value (const_tree, const_tree, enum machine_mode);
 extern bool riscv_store_data_bypass_p (rtx_insn *, rtx_insn *);
+extern bool riscv_fix_operands_ld_sd (rtx *operands, bool load,
+				      bool const_store, bool commute);
+extern bool riscv_valid_operands_ld_sd (rtx *operands);
+extern const char *riscv_output_move_double (rtx *operands);
 extern rtx riscv_gen_gpr_save_insn (struct riscv_frame_info *);
 extern bool riscv_gpr_save_operation_p (rtx);
 extern void riscv_reinit (void);

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -4119,7 +4119,13 @@ riscv_split_64bit_move_p (rtx dest, rtx src)
 	  || (FP_REG_RTX_P (dest) && src == CONST0_RTX (GET_MODE (src)))))
     return false;
 
-  return true;
+  if (TARGET_ZILSD
+      && (reload_in_progress || reload_completed)
+      && ((GP_REG_RTX_P (src) && ((REGNO(src) % 2) == 0) && MEM_P (dest))
+	  || (GP_REG_RTX_P (dest) && ((REGNO(dest) % 2) == 0) && MEM_P (src))))
+    return false;
+
+   return true;
 }
 
 /* Split a doubleword move from SRC to DEST.  On 32-bit targets,
@@ -8912,6 +8918,328 @@ riscv_hard_regno_mode_ok (unsigned int regno, machine_mode mode)
 
   return true;
 }
+
+/* Checks whether the operands are valid for use in an LD/SD instruction.
+   Assumes that RT, RT2 are REG.  This is guaranteed by the patterns.
+   Assumes that the address in the base register RN is word aligned.  Pattern
+   guarantees that both memory accesses use the same base register,
+   the offsets are constants within the range, and the gap between the offsets is 4.
+   If preload complete then check that registers are legal. */
+static bool
+riscv_operands_ok_ld_sd (rtx rt, rtx rt2, HOST_WIDE_INT offset)
+{
+  unsigned int t, t2;
+
+  if (!reload_completed)
+    return true;
+
+  if ((offset > 4095) || (offset < -4095))
+    return false;
+
+  t = REGNO (rt);
+  t2 = REGNO (rt2);
+
+  if ((t % 2 != 0)   /* First destination register is not even.  */
+      || (t2 != t + 1))
+    return false;
+
+  return true;
+}
+
+/* Helper for riscv_fix_operands_ld_sd.  Returns true iff the memory
+   operand MEM's address contains an immediate offset from the base
+   register and has no side effects, in which case it sets BASE,
+   OFFSET and ALIGN accordingly.  */
+static bool
+riscv_mem_ok_for_ld_sd (rtx mem, rtx *base, rtx *offset, HOST_WIDE_INT *align)
+{
+  rtx addr;
+
+  gcc_assert (base != NULL && offset != NULL);
+
+  if (side_effects_p (mem))
+    return false;
+
+  /* Can't deal with subregs.  */
+  if (SUBREG_P (mem))
+    return false;
+
+  gcc_assert (MEM_P (mem));
+
+  *offset = const0_rtx;
+  *align = MEM_ALIGN (mem);
+
+  addr = XEXP (mem, 0);
+
+  /* If addr isn't valid for DImode, then we can't handle it.  */
+  if (!riscv_legitimate_address_p (DImode, addr,
+				   reload_in_progress || reload_completed))
+    return false;
+
+  if (REG_P (addr))
+    {
+      *base = addr;
+      return true;
+    }
+  else if (GET_CODE (addr) == PLUS)
+    {
+      *base = XEXP (addr, 0);
+      *offset = XEXP (addr, 1);
+      return (REG_P (*base) && CONST_INT_P (*offset));
+    }
+
+  return false;
+}
+
+/* Called from a peephole2 to replace two word-size accesses with a
+   single LD/SD instruction.  Returns true iff we can generate a
+   new instruction sequence.  That is, both accesses use the same base
+   register and the gap between constant offsets is 4.  This function
+   may reorder its operands to match ld/sd RTL templates.
+   OPERANDS are the operands found by the peephole matcher;
+   OPERANDS[0,1] are register operands, and OPERANDS[2,3] are the
+   corresponding memory operands.  LOAD indicaates whether the access
+   is load or store.  CONST_STORE indicates a store of constant
+   integer values held in OPERANDS[4,5] and assumes that the pattern
+   is of length 4 insn, for the purpose of checking dead registers.
+   COMMUTE indicates that register operands may be reordered.  */
+bool
+riscv_fix_operands_ld_sd (rtx *operands, bool load,
+			  bool const_store, bool commute)
+{
+  int nops = 2;
+  HOST_WIDE_INT offsets[2], offset, align[2];
+  rtx base = NULL_RTX;
+  rtx cur_base, cur_offset, tmp;
+  int i, gap;
+  HARD_REG_SET regset;
+
+  gcc_assert (!const_store || !load);
+  /* Check that the memory references are immediate offsets from the
+     same base register.  Extract the base register, the destination
+     registers, and the corresponding memory offsets.  */
+  for (i = 0; i < nops; i++)
+    {
+      if (!riscv_mem_ok_for_ld_sd (operands[nops+i], &cur_base, &cur_offset,
+				   &align[i]))
+        return false;
+
+      if (i == 0)
+        base = cur_base;
+      else if (REGNO (base) != REGNO (cur_base))
+        return false;
+
+      offsets[i] = INTVAL (cur_offset);
+      if (GET_CODE (operands[i]) == SUBREG)
+        {
+          tmp = SUBREG_REG (operands[i]);
+          gcc_assert (GET_MODE (operands[i]) == GET_MODE (tmp));
+          operands[i] = tmp;
+        }
+    }
+
+  /* Make sure there is no dependency between the individual loads.  */
+  if (load && REGNO (operands[0]) == REGNO (base))
+    return false; /* RAW */
+
+  if (load && REGNO (operands[0]) == REGNO (operands[1]))
+    return false; /* WAW */
+
+  /* If the same input register is used in both stores
+     when storing different constants, try to find a free register.
+     For example, the code
+	mv r0, 0
+	sw r0, 0(r2)
+	mv r0, 1
+	sw r0, 4(r2)
+     can be transformed into
+	mv r1, 0
+	mv r0, 1
+	sd r0, 0(r2)
+     assuming that r1 is free. */
+  if (const_store
+      && REGNO (operands[0]) == REGNO (operands[1])
+      && INTVAL (operands[4]) != INTVAL (operands[5]))
+    {
+      int regno = REGNO (operands[0]);
+      if (!peep2_reg_dead_p (4, operands[0]))
+	{
+	  /* When the input register is even and is not dead after the
+	     pattern, it has to hold the second constant but we cannot
+	     form a legal SD with this register as the second register.  */
+	  if (regno % 2 == 0)
+	    return false;
+
+	  /* Is regno-1 free? */
+	  SET_HARD_REG_SET (regset);
+	  CLEAR_HARD_REG_BIT(regset, regno - 1);
+	  tmp = peep2_find_free_register (0, 4, "r", SImode, &regset);
+	  if (tmp == NULL_RTX)
+	    return false;
+
+	  operands[0] = tmp;
+	}
+      else
+	{
+	  /* Can we use the input register to form a DI register?  */
+	  SET_HARD_REG_SET (regset);
+	  CLEAR_HARD_REG_BIT(regset,
+			     regno % 2 == 0 ? regno + 1 : regno - 1);
+	  tmp = peep2_find_free_register (0, 4, "r", SImode, &regset);
+	  if (tmp == NULL_RTX)
+	    return false;
+	  operands[regno % 2 == 1 ? 0 : 1] = tmp;
+	}
+
+      gcc_assert (operands[0] != NULL_RTX);
+      gcc_assert (operands[1] != NULL_RTX);
+      gcc_assert (REGNO (operands[0]) % 2 == 0);
+      gcc_assert (REGNO (operands[1]) == REGNO (operands[0]) + 1);
+    }
+
+  /* Make sure the instructions are ordered with lower memory access first.  */
+  if (offsets[0] > offsets[1])
+    {
+      gap = offsets[0] - offsets[1];
+      offset = offsets[1];
+
+      /* Swap the instructions such that lower memory is accessed first.  */
+      std::swap (operands[0], operands[1]);
+      std::swap (operands[2], operands[3]);
+      std::swap (align[0], align[1]);
+      if (const_store)
+        std::swap (operands[4], operands[5]);
+    }
+  else
+    {
+      gap = offsets[1] - offsets[0];
+      offset = offsets[0];
+    }
+
+  /* Make sure accesses are to consecutive memory locations.  */
+  if (gap != GET_MODE_SIZE (SImode))
+    return false;
+
+  /* Make sure we generate legal instructions.  */
+  if (riscv_operands_ok_ld_sd (operands[0], operands[1], offset))
+    return true;
+
+  if (load && commute)
+    {
+      /* Try reordering registers.  */
+      std::swap (operands[0], operands[1]);
+      if (riscv_operands_ok_ld_sd (operands[0], operands[1], offset))
+        return true;
+    }
+
+  if (const_store)
+    {
+      /* If input registers are dead after this pattern, they can be
+         reordered or replaced by other registers that are free in the
+         current pattern.  */
+      if (!peep2_reg_dead_p (4, operands[0])
+          || !peep2_reg_dead_p (4, operands[1]))
+        return false;
+
+      /* Try to reorder the input registers.  */
+      /* For example, the code
+           mv r0, 0
+           mv r1, 1
+           sw r1, 0(r2)
+           sw r0, 4(r2)
+         can be transformed into
+           mv r1, 0
+           mv r0, 1
+           sd r0, 0(r2)
+      */
+      if (riscv_operands_ok_ld_sd (operands[1], operands[0], offset))
+        {
+          std::swap (operands[0], operands[1]);
+          return true;
+        }
+    }
+
+  return false;
+}
+
+/* Return true if parallel execution of the two word-size accesses provided
+   could be satisfied with a single LD/SD instruction.  Two word-size
+   accesses are represented by the OPERANDS array, where OPERANDS[0,1] are
+   register operands and OPERANDS[2,3] are the corresponding memory operands.
+   */
+bool
+riscv_valid_operands_ld_sd (rtx *operands)
+{
+  int nops = 2;
+  HOST_WIDE_INT offsets[2], offset, align[2];
+  rtx base = NULL_RTX;
+  rtx cur_base, cur_offset;
+  int i, gap;
+
+  /* Check that the memory references are immediate offsets from the
+     same base register.  Extract the base register, the destination
+     registers, and the corresponding memory offsets.  */
+  for (i = 0; i < nops; i++)
+    {
+      if (!riscv_mem_ok_for_ld_sd (operands[nops+i], &cur_base, &cur_offset,
+				   &align[i]))
+	return false;
+
+      if (i == 0)
+	base = cur_base;
+      else if (REGNO (base) != REGNO (cur_base))
+	return false;
+
+      offsets[i] = INTVAL (cur_offset);
+      if (GET_CODE (operands[i]) == SUBREG)
+	return false;
+    }
+
+  if (offsets[0] > offsets[1])
+    return false;
+
+  gap = offsets[1] - offsets[0];
+  offset = offsets[0];
+
+  /* Make sure accesses are to consecutive memory locations.  */
+  if (gap != GET_MODE_SIZE (SImode))
+    return false;
+
+  return riscv_operands_ok_ld_sd (operands[0], operands[1], offset);
+}
+
+/* Output a move between double words.  It must be REG<-MEM
+   or MEM<-REG.  */
+const char *
+riscv_output_move_double (rtx *operands)
+{
+  enum rtx_code code0 = GET_CODE (operands[0]);
+  enum rtx_code code1 = GET_CODE (operands[1]);
+
+  if (code0 == REG)
+    {
+      unsigned int reg0 = REGNO (operands[0]);
+
+      /* Constraints should ensure this.  */
+      gcc_assert (code1 == MEM);
+      gcc_assert (reg0 % 2 == 0);
+
+      output_asm_insn ("ld\t%0, %1", operands);
+    }
+  else /* It is a store */
+    {
+      unsigned int reg1 = REGNO (operands[1]);
+
+      /* Constraints should ensure this.  */
+      gcc_assert (code0 == MEM && code1 == REG);
+      gcc_assert (reg1 % 2 == 0);
+
+      output_asm_insn ("sd\t%z1, %0", operands);
+    }
+
+  return "";
+}
+
 
 /* Implement TARGET_MODES_TIEABLE_P.
 

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -400,6 +400,7 @@ ASM_MISA_SPEC
   TEST_HARD_REG_BIT (reg_class_contents[SIBCALL_REGS], REGNO)
 
 #define FP_REG_RTX_P(X) (REG_P (X) && FP_REG_P (REGNO (X)))
+#define GP_REG_RTX_P(X) (REG_P (X) && GP_REG_P (REGNO (X)))
 
 /* Use s0 as the frame pointer if it is so requested.  */
 #define HARD_FRAME_POINTER_REGNUM 8

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -2384,7 +2384,7 @@
 (define_insn "*movdi_32bit"
   [(set (match_operand:DI 0 "nonimmediate_operand" "=r,r,r,m,  *f,*f,*r,*f,*m,r")
 	(match_operand:DI 1 "move_operand"         " r,i,m,r,*J*r,*m,*f,*f,*f,vp"))]
-  "!TARGET_64BIT
+  "(!TARGET_64BIT && !TARGET_ZILSD)
    && (register_operand (operands[0], DImode)
        || reg_or_0_operand (operands[1], DImode))"
   { return riscv_output_move (operands[0], operands[1]); }
@@ -2396,7 +2396,7 @@
 (define_insn "*movdi_64bit"
   [(set (match_operand:DI 0 "nonimmediate_operand" "=r,r,r, m,  *f,*f,*r,*f,*m,r")
 	(match_operand:DI 1 "move_operand"         " r,T,m,rJ,*r*J,*m,*f,*f,*f,vp"))]
-  "TARGET_64BIT
+  "(TARGET_64BIT || TARGET_ZILSD)
    && (register_operand (operands[0], DImode)
        || reg_or_0_operand (operands[1], DImode))"
   { return riscv_output_move (operands[0], operands[1]); }
@@ -2619,7 +2619,8 @@
   [(set (match_operand:MOVE64 0 "nonimmediate_operand")
 	(match_operand:MOVE64 1 "move_operand"))]
   "reload_completed
-   && riscv_split_64bit_move_p (operands[0], operands[1])"
+   && (riscv_split_64bit_move_p (operands[0], operands[1])
+       || TARGET_ZILSD)"
   [(const_int 0)]
 {
   riscv_split_doubleword_move (operands[0], operands[1]);

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -224,6 +224,8 @@ Use the given offset for addressing the stack-protector guard.
 TargetVariable
 long riscv_stack_protector_guard_offset = 0
 
+Mask(ZILSD)       Var(riscv_zi_subext)
+
 TargetVariable
 int riscv_zi_subext
 

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -436,7 +436,7 @@ Mask(ZCMP) Var(riscv_zc_subext)
 
 Mask(ZCMT) Var(riscv_zc_subext)
 
-Mask(ZCMLSD) Var(riscv_zi_subext)
+Mask(ZCLSD) Var(riscv_zc_subext)
 
 Mask(XCVBI) Var(riscv_xcv_subext)
 

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -224,8 +224,6 @@ Use the given offset for addressing the stack-protector guard.
 TargetVariable
 long riscv_stack_protector_guard_offset = 0
 
-Mask(ZILSD)       Var(riscv_zi_subext)
-
 TargetVariable
 int riscv_zi_subext
 
@@ -246,6 +244,8 @@ Mask(ZICCIF)      Var(riscv_zi_subext)
 Mask(ZICCLSM)     Var(riscv_zi_subext)
 
 Mask(ZICCRSE)     Var(riscv_zi_subext)
+
+Mask(ZILSD)       Var(riscv_zi_subext)
 
 TargetVariable
 int riscv_za_subext
@@ -435,6 +435,8 @@ Mask(ZCD)  Var(riscv_zc_subext)
 Mask(ZCMP) Var(riscv_zc_subext)
 
 Mask(ZCMT) Var(riscv_zc_subext)
+
+Mask(ZCMLSD) Var(riscv_zi_subext)
 
 Mask(XCVBI) Var(riscv_xcv_subext)
 

--- a/gcc/testsuite/gcc.target/riscv/zilsd.c
+++ b/gcc/testsuite/gcc.target/riscv/zilsd.c
@@ -1,0 +1,54 @@
+/* { dg-do compile } */
+/* { dg-options "-O2 -march=rv32imc_zilsd -mabi=ilp32" { target { rv32 } } } */
+/* { dg-skip-if "" { *-*-* } {"-O0" "-Og" "-g" "-ansi"} } */
+/* { dg-skip-if "" { riscv64*-*-* } } */
+typedef int T;
+typedef long long int LT;
+typedef struct {
+  int w;
+  int x;
+  int y;
+  int z;
+} S;
+
+T peep_load_4 (S *p)
+{
+  return p->x + p->w + p->y + p->z;
+}
+
+T peep_load_3 (S *p)
+{
+  return p->x + p->w + p->y;
+}
+
+void peep_store_4 (S *p, int w, int x, int y, int z)
+{
+  p->w = w;
+  p->x = x;
+  p->y = y;
+  p->z = z;
+}
+
+void peep_store_2 (int a, int b, S *p)
+{
+  p->w = a;
+  p->x = b;
+}
+
+void peep_constant_2 (S *p)
+{
+  p->w = 0x55;
+  p->x = 0xAA;
+}
+
+LT data64 (LT a)
+{
+  volatile LT x;
+  volatile LT y;
+
+  x = a;
+  return x + y;
+}
+
+/* { dg-final { scan-assembler-times "ld\t" 2 } } */
+/* { dg-final { scan-assembler-times "sd\t" 3 } } */

--- a/gcc/testsuite/gcc.target/riscv/zilsd.c
+++ b/gcc/testsuite/gcc.target/riscv/zilsd.c
@@ -50,5 +50,5 @@ LT data64 (LT a)
   return x + y;
 }
 
-/* { dg-final { scan-assembler-times "ld\t" 2 } } */
+/* { dg-final { scan-assembler-times "ld\t" 1 } } */
 /* { dg-final { scan-assembler-times "sd\t" 3 } } */

--- a/gcc/testsuite/gcc.target/riscv/zilsd2.c
+++ b/gcc/testsuite/gcc.target/riscv/zilsd2.c
@@ -1,0 +1,55 @@
+/* { dg-do compile } */
+/* { dg-options "-O2 -march=rv32imc_zilsd -mabi=ilp32 -fno-inline" { target { rv32 } } } */
+/* { dg-skip-if "" { *-*-* } {"-O0" "-Og" "-g" "-ansi"} } */
+/* { dg-skip-if "" { riscv64*-*-* } } */
+
+#include <stdint.h>
+
+uint64_t in_m, in_a, in_b;
+
+void
+mulul64 (uint64_t u, uint64_t v, uint64_t * whi, uint64_t * wlo)
+{
+  uint64_t u0, u1, v0, v1, k, t;
+  uint64_t w0;
+
+  u1 = u >> 32;
+  v1 = v >> 32;
+
+  t = u0 * v0;
+  w0 = t & 0xFFFFFFFF;
+  k = t >> 32;
+
+  *wlo = (t << 32) + w0;
+  *whi = u1 * v1 + k;
+
+  return;
+}
+
+uint64_t
+modul64 (uint64_t x, uint64_t y, uint64_t z)
+{
+  return x;                     // Quotient is y.
+}
+
+uint64_t
+foo (void)
+{
+  uint64_t a, b, m, hr, p1hi, p1lo, p1;
+
+  m = in_m;                 // Must be odd.
+  b = in_b;                 // Must be smaller than m.
+  a = in_a;                 // Must be smaller than m.
+
+  mulul64 (a, b, &p1hi, &p1lo);     // Compute a*b (mod m).
+  p1 = modul64 (p1hi, p1lo, m);
+  mulul64 (p1, p1, &p1hi, &p1lo);   // Compute (a*b)**2 (mod m).
+  p1 = modul64 (p1hi, p1lo, m);
+
+  return p1;
+}
+
+/* { dg-final { scan-assembler-times "ld\t" 2 } } */
+/* { dg-final { scan-assembler-times "sd\t" 1 } } */
+/* { dg-final { scan-assembler-times "mv\ta2,a0" 1 } } */
+/* { dg-final { scan-assembler-times "mv\ta3,a1" 1 } } */


### PR DESCRIPTION
The code incorporates the following changes:

1. According to the manual specifications, zcmlsd was changed to zclsd.

2. Constraints were added for zilsd and zclsd.
